### PR TITLE
Raise an exception when attempting to insert before an invalid middleware

### DIFF
--- a/lib/middleware/builder.rb
+++ b/lib/middleware/builder.rb
@@ -67,6 +67,7 @@ module Middleware
     # given middleware object.
     def insert(index, middleware, *args, &block)
       index = self.index(index) unless index.is_a?(Integer)
+      raise "no such middleware to insert before: #{index.inspect}" unless index
       stack.insert(index, [middleware, args, block])
     end
 

--- a/spec/middleware/builder_spec.rb
+++ b/spec/middleware/builder_spec.rb
@@ -90,6 +90,11 @@ describe Middleware::Builder do
       data[:data].should == [2, 1]
     end
 
+    it "raises an exception if attempting to insert before an invalid object" do
+      expect { instance.insert "object", appender_proc(1) }.
+        to raise_error(RuntimeError)
+    end
+
     it "can insert after" do
       instance.use appender_proc(1)
       instance.use appender_proc(3)
@@ -99,7 +104,7 @@ describe Middleware::Builder do
       data[:data].should == [1, 2, 3]
     end
 
-    it "raises an exception if an invalid object given" do
+    it "raises an exception if attempting to insert after an invalid object" do
       expect { instance.insert_after "object", appender_proc(1) }.
         to raise_error(RuntimeError)
     end


### PR DESCRIPTION
Builder raises an exception when attempting to insert _after_ an invalid middleware, but not before. Note that `#delete` and `#replace` would still have inconsistent behavior around this.
