### PR TITLE
return env from Runner#call

### DIFF
--- a/lib/middleware/runner.rb
+++ b/lib/middleware/runner.rb
@@ -29,6 +29,10 @@ module Middleware
       # for properly calling the next middleware, and so on and so
       # forth.
       @kickoff.call(env)
+
+      # return env so the caller can make use of it after
+      # the middleware chain has finished
+      env
     end
 
     protected

--- a/spec/middleware/runner_spec.rb
+++ b/spec/middleware/runner_spec.rb
@@ -111,6 +111,18 @@ describe Middleware::Runner do
     data.should == ["a"]
   end
 
+  it "should return env from call" do
+    env = {}
+
+    a = lambda { |env| env[:a_called] = true }
+    b = lambda { |env| env[:b_called] = true }
+
+    instance = described_class.new([a, b])
+    ret = instance.call(env)
+
+    ret.should == env
+  end
+
   describe "exceptions" do
     it "should propagate the exception up the middleware chain" do
       # This tests a few important properties:


### PR DESCRIPTION
Slightly different implementation to #3, feels a bit more explicit and obvious as to what's going on when reading the source. Also has tests.
