### PR TITLE
Setup GitHub Actions and update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push,pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['1.9.3', 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, head, jruby, truffleruby]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - name: Run the default task
+      run: |
+        bundle exec rake

--- a/middleware.gemspec
+++ b/middleware.gemspec
@@ -10,11 +10,10 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "redcarpet", "~> 2.1.0"
   gem.add_development_dependency "rspec-core", "~> 3.10.0"
   gem.add_development_dependency "rspec-expectations", "~> 3.10.0"
   gem.add_development_dependency "rspec-mocks", "~> 3.10.0"
-  gem.add_development_dependency "yard", "~> 0.7.5"
+  gem.add_development_dependency "yard", "~> 0.9"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")

--- a/middleware.gemspec
+++ b/middleware.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "redcarpet", "~> 2.1.0"
-  gem.add_development_dependency "rspec-core", "~> 2.8.0"
-  gem.add_development_dependency "rspec-expectations", "~> 2.8.0"
-  gem.add_development_dependency "rspec-mocks", "~> 2.8.0"
+  gem.add_development_dependency "rspec-core", "~> 3.10.0"
+  gem.add_development_dependency "rspec-expectations", "~> 3.10.0"
+  gem.add_development_dependency "rspec-mocks", "~> 3.10.0"
   gem.add_development_dependency "yard", "~> 0.7.5"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/spec/middleware/runner_spec.rb
+++ b/spec/middleware/runner_spec.rb
@@ -148,7 +148,7 @@ describe Middleware::Runner do
 
       env = {}
       instance = described_class.new([a, b, c])
-      expect { instance.call(env) }.to raise_error
+      expect { instance.call(env) }.to raise_error(RuntimeError)
 
       data.should == ["a", "b", "e"]
     end

--- a/spec/setup.rb
+++ b/spec/setup.rb
@@ -1,5 +1,4 @@
 require "rubygems"
-require "rspec/autorun"
 
 # Do not buffer output
 $stdout.sync = true
@@ -7,4 +6,7 @@ $stderr.sync = true
 
 # Configure RSpec
 RSpec.configure do |c|
+  c.expect_with :rspec do |expectations|
+    expectations.syntax = [:should, :expect] # Both syntax are used so we need to explicitly set this to suppress warnings
+  end
 end


### PR DESCRIPTION
Using travis-ci.org as a CI service is not possible now. We can migrate to travis-ci.com or GitHub Actions, so it's an attempt to use GitHub Actions as a CI service.
To run `bundle exec rake` some dependencies must be updated. After updating RSpec some modifications are required to suppress deprecation warnings.