### PR TITLE
Fix keyword argument passing in Ruby 3

### DIFF
--- a/lib/middleware/builder.rb
+++ b/lib/middleware/builder.rb
@@ -52,12 +52,12 @@ module Middleware
     # of the middleware.
     #
     # @param [Class] middleware The middleware class
-    def use(middleware, *args, &block)
+    def use(middleware, *args, **kwargs, &block)
       if middleware.kind_of?(Builder)
         # Merge in the other builder's stack into our own
         self.stack.concat(middleware.stack)
       else
-        self.stack << [middleware, args, block]
+        self.stack << [middleware, args, kwargs, block]
       end
 
       self

--- a/lib/middleware/runner.rb
+++ b/lib/middleware/runner.rb
@@ -42,7 +42,7 @@ module Middleware
       # is always the empty middleware, which does nothing but return.
       stack.reverse.inject(EMPTY_MIDDLEWARE) do |next_middleware, current_middleware|
         # Unpack the actual item
-        klass, args, block = current_middleware
+        klass, args, kwargs, block = current_middleware
 
         # Default the arguments to an empty array. Otherwise in Ruby 1.8
         # a `nil` args will actually pass `nil` into the class. Not what
@@ -52,7 +52,7 @@ module Middleware
         if klass.is_a?(Class)
           # If the klass actually is a class, then instantiate it with
           # the app and any other arguments given.
-          klass.new(next_middleware, *args, &block)
+          klass.new(next_middleware, *args, **kwargs, &block)
         elsif klass.respond_to?(:call)
           # Make it a lambda which calls the item then forwards up
           # the chain.


### PR DESCRIPTION
In Ruby 3, keyword arguments has to be splat into its own using double splat.

See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

This fixes the following error:

```log
in `initialize': wrong number of arguments (given 2, expected 1; required keyword: foo) (ArgumentError)
```